### PR TITLE
Board와 Reply 엔티티 등록

### DIFF
--- a/src/main/java/project/olineworkout/domain/entity/Board/Board.java
+++ b/src/main/java/project/olineworkout/domain/entity/Board/Board.java
@@ -1,0 +1,77 @@
+package project.olineworkout.domain.entity.Board;
+
+import com.sun.istack.NotNull;
+import lombok.*;
+import project.olineworkout.domain.entity.User.User;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name="tbl_board")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bno;
+
+    @NotNull //nullable = false 와는 달리 유효성 검사까지 해줌
+    private String title;
+
+    private String content;
+    private String theme;   //게시판 테마
+
+    private LocalDate createDate;
+    private LocalDate updateDate;
+
+    private Long likeCount;
+    private Long viewCount;
+    private Long replyCount;
+
+    @ManyToOne
+    @JoinColumn(name = "uno")
+    private User user;
+
+    @Builder
+    public Board(String title, String content, String theme, LocalDate createDate, LocalDate updateDate
+            , Long likeCount, Long viewCount, Long replyCount, User user) {
+
+        this.title = title;
+        this.content = content;
+        this.theme = theme;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.replyCount = replyCount;
+        this.user = user;
+    }
+
+    public void updateBoard(String title, String content){
+
+        this.title = title;
+        this.content = content;
+        this.updateDate = LocalDate.now();
+    }
+
+    public void viewCountUp(){
+        this.viewCount += 1;
+    }
+    public void likeCountUp(){
+        this.likeCount += 1;
+    }
+    public void likeCountDown(){
+        if(likeCount > 0)
+            this.likeCount -= 1;
+    }
+    public void replyCountUp(){
+        this.replyCount += 1;
+    }
+    public void replyCountDown(){
+        if(likeCount > 0)
+            this.replyCount -= 1;
+    }
+}

--- a/src/main/java/project/olineworkout/domain/entity/Board/BoardType.java
+++ b/src/main/java/project/olineworkout/domain/entity/Board/BoardType.java
@@ -1,0 +1,8 @@
+package project.olineworkout.domain.entity.Board;
+
+
+public enum BoardType {
+
+    //질문, 공지사항, 홍보글, 자유게시판, 개인화 루틴
+    QNA, NOTICE, ADVERTISE, FREE_BOARD, SELF_ROUTINE
+}

--- a/src/main/java/project/olineworkout/domain/entity/Reply/Reply.java
+++ b/src/main/java/project/olineworkout/domain/entity/Reply/Reply.java
@@ -1,0 +1,40 @@
+package project.olineworkout.domain.entity.Reply;
+
+import lombok.*;
+import project.olineworkout.domain.entity.Board.Board;
+import project.olineworkout.domain.entity.User.User;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name="tbl_reply")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Reply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long rno;
+
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "uno")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "bno") //외래키를 매핑할 때 사용.
+    private Board board;
+
+    @Builder
+    public Reply(String content, User user, Board board) {
+        this.content = content;
+        this.user = user;
+        this.board = board;
+    }
+
+    public void updateContent(String content){
+        this.content = content;
+    }
+}

--- a/src/main/java/project/olineworkout/domain/entity/User/User.java
+++ b/src/main/java/project/olineworkout/domain/entity/User/User.java
@@ -1,0 +1,19 @@
+package project.olineworkout.domain.entity.User;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name="tbl_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long uno;
+}


### PR DESCRIPTION
User, Board, Reply, BoardType(Enum) 엔티티 생성

User는 Board, Reply 연관 관계를 위해 기본만 작성

Board, Reply 엔티티 등록 및 속성값 추가
Board, Reply 빌더 패턴 이용한 생성자 추가
게시판 수정 기능 메소드 추가
조회, 댓글, 좋아요 수 증가, 감소 메소드 추가
Board, Reply이 User 엔티티와 연관관계 위해 간단하게 User 엔티티 등록
BoardType (Enum) 생성